### PR TITLE
Agregar plantilla y gestión completa de votaciones

### DIFF
--- a/static/js/asistencia.js
+++ b/static/js/asistencia.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const uploadInput = document.getElementById('fileInput');
   const uploadBtn = document.getElementById('uploadBtn');
+  const templateBtn = document.getElementById('templateBtn');
 
   const pieChart = new Chart(document.getElementById('pieChart').getContext('2d'), {
     type: 'pie',
@@ -135,6 +136,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('exportExcel').addEventListener('click', () => window.location = '/export/excel');
   document.getElementById('exportCsv').addEventListener('click', () => window.location = '/export/csv');
   document.getElementById('exportPdf').addEventListener('click', () => window.location = '/export/pdf');
+  if (templateBtn) templateBtn.addEventListener('click', () => window.location = '/template/asistencia');
 
   uploadBtn.addEventListener('click', () => {
     const file = uploadInput.files[0];
@@ -145,6 +147,7 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(r => r.json())
       .then(res => {
         if (res.ok) {
+          alert('Importación exitosa');
           load();
         } else {
           alert(res.error || 'Error al importar');

--- a/templates/asistencia_panel.html
+++ b/templates/asistencia_panel.html
@@ -22,6 +22,7 @@
   <div class="import">
     <input type="file" id="fileInput" accept=".xlsx,.xls">
     <button id="uploadBtn">Importar</button>
+    <button id="templateBtn">Descargar plantilla Excel</button>
   </div>
 
   <div class="filters">

--- a/templates/edit_votacion.html
+++ b/templates/edit_votacion.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block title %}Editar votación{% endblock %}
+{% block content %}
+<header class="header">
+  <h1>Editar votación</h1>
+  <a class="logout" href="{{ url_for('logout') }}"><i class="fas fa-sign-out-alt"></i> Cerrar sesión</a>
+</header>
+<div class="card">
+  <form id="votacion-form" action="{{ url_for('admin_update_votacion', votacion_id=data['id']) }}">
+    <input type="text" id="nombre_votacion" placeholder="Nombre de votación" required>
+    <input type="date" id="fecha">
+    <label>Asignar usuarios</label>
+    <select id="usuarios-select" multiple>
+      {% for u in users if u['role'] == 'votante' %}
+        <option value="{{ u['id'] }}">{{ u['username'] }}</option>
+      {% endfor %}
+    </select>
+    <div id="preguntas-container"></div>
+    <button type="button" id="add-pregunta">+ Añadir pregunta</button>
+    <button type="submit">Guardar</button>
+  </form>
+</div>
+<script>
+  window.initialData = {{ data | tojson }};
+</script>
+<script src="{{ url_for('static', filename='js/votaciones.js') }}"></script>
+{% endblock %}

--- a/templates/panel_admin.html
+++ b/templates/panel_admin.html
@@ -58,21 +58,6 @@
     </table>
   </div>
 
-  <div class="card">
-    <h2>Asignar usuario a votación</h2>
-    <form method="post" action="{{ url_for('admin_asignar') }}">
-      <label>Usuario</label>
-      <input type="number" name="user_id" placeholder="ID Usuario" required>
-      <label>Votación</label>
-      <input type="number" name="votacion_id" placeholder="ID Votación" required>
-      <label>Rol</label>
-      <select name="rol">
-        <option value="asistencia">asistencia</option>
-        <option value="votante">votante</option>
-      </select>
-      <button type="submit">Asignar</button>
-    </form>
-  </div>
 </section>
 
 <section id="votaciones" class="tab-section hidden">
@@ -81,6 +66,12 @@
     <form id="votacion-form" action="{{ url_for('admin_create_votacion') }}">
       <input type="text" id="nombre_votacion" placeholder="Nombre de votación" required>
       <input type="date" id="fecha">
+      <label>Asignar usuarios</label>
+      <select id="usuarios-select" multiple>
+        {% for u in users if u['role'] == 'votante' %}
+          <option value="{{ u['id'] }}">{{ u['username'] }}</option>
+        {% endfor %}
+      </select>
       <div id="preguntas-container"></div>
       <button type="button" id="add-pregunta">+ Añadir pregunta</button>
       <button type="submit">Guardar</button>
@@ -96,6 +87,7 @@
           <th>Fecha</th>
           <th># Preguntas</th>
           <th>Asistentes asignados</th>
+          <th>Acciones</th>
         </tr>
       </thead>
       <tbody>
@@ -105,6 +97,12 @@
           <td>{{ v['fecha'] or '' }}</td>
           <td>{{ v['num_preguntas'] }}</td>
           <td>{{ v['asistentes'] }}</td>
+          <td>
+            <a href="{{ url_for('admin_edit_votacion', votacion_id=v['id']) }}">Editar</a>
+            <form method="post" action="{{ url_for('admin_delete_votacion', votacion_id=v['id']) }}" style="display:inline" onsubmit="return confirm('¿Eliminar votación?');">
+              <button type="submit">Eliminar</button>
+            </form>
+          </td>
         </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
## Summary
- add endpoint and UI to download attendance Excel template
- show alerts on import and refresh table
- enable assigning users to votaciones via multi-select and support editing/deleting votaciones

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6891064bf24c83229780487ca6f8df7c