### PR TITLE
Use CDN Socket.IO client

### DIFF
--- a/templates/asistencia_panel.html
+++ b/templates/asistencia_panel.html
@@ -63,7 +63,7 @@
   <canvas id="pieChart"></canvas>
   <canvas id="barChart"></canvas>
 </div>
-<script src="/socket.io/socket.io.js"></script>
+<script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="{{ url_for('static', filename='js/asistencia.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Load Socket.IO client from CDN to avoid protocol mismatch errors.

## Testing
- `python -m py_compile app.py`
- `pytest`
- `pip show flask-socketio python-socketio` *(missing packages)*
- `python app.py` *(failed: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_6891137f13ac83229413c24477ba6cf1