### PR TITLE
Use CDN Socket.IO client and resize charts

### DIFF
--- a/app.py
+++ b/app.py
@@ -487,13 +487,13 @@ def export(fmt):
     elif fmt == 'pdf' and HAS_MPL:
         fname = f"{base}.pdf"
         with PdfPages(fname) as pdf:
-            fig, ax = plt.subplots()
+            fig, ax = plt.subplots(figsize=(4, 4))
             df['estado'].value_counts().plot.pie(ax=ax, autopct='%1.1f%%')
             ax.set_ylabel('')
             pdf.savefig(fig)
             plt.close(fig)
 
-            fig2, ax2 = plt.subplots()
+            fig2, ax2 = plt.subplots(figsize=(5, 3))
             df.groupby('estado')['acciones'].sum().plot.bar(ax=ax2)
             ax2.set_ylabel('Total Acciones')
             pdf.savefig(fig2)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -118,6 +118,18 @@ canvas {
     margin-top: 15px;
 }
 
+.charts {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 20px;
+}
+
+.charts canvas {
+    width: 300px;
+    height: 300px;
+}
+
 @media (max-width: 600px) {
     .container {
         margin: 10px;

--- a/static/js/asistencia.js
+++ b/static/js/asistencia.js
@@ -17,7 +17,8 @@ document.addEventListener('DOMContentLoaded', () => {
     data: {
       labels: ['Presencial', 'Virtual', 'Ausente'],
       datasets: [{ data: [0, 0, 0], backgroundColor: ['#4CAF50', '#2196F3', '#f44336'] }]
-    }
+    },
+    options: { responsive: true, maintainAspectRatio: false }
   });
 
   const barChart = new Chart(document.getElementById('barChart').getContext('2d'), {
@@ -26,7 +27,11 @@ document.addEventListener('DOMContentLoaded', () => {
       labels: ['Presencial', 'Virtual', 'Ausente'],
       datasets: [{ label: 'Acciones', data: [0, 0, 0], backgroundColor: ['#4CAF50', '#2196F3', '#f44336'] }]
     },
-    options: { scales: { y: { beginAtZero: true } } }
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: { y: { beginAtZero: true } }
+    }
   });
 
   let rows = [];

--- a/templates/asistencia_panel.html
+++ b/templates/asistencia_panel.html
@@ -60,10 +60,12 @@
   </table>
 
   <div id="summary"></div>
-  <canvas id="pieChart"></canvas>
-  <canvas id="barChart"></canvas>
+  <div class="charts">
+    <canvas id="pieChart" width="300" height="300"></canvas>
+    <canvas id="barChart" width="300" height="300"></canvas>
+  </div>
 </div>
-<script src="/socket.io/socket.io.js"></script>
+<script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="{{ url_for('static', filename='js/asistencia.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Load Socket.IO client from CDN to avoid protocol mismatch errors.
- Group and resize attendance charts for better on-screen layout and PDF export.

## Testing
- `pip install 'flask' 'flask-socketio==5.*' 'python-socketio==5.*'` *(failed: Tunnel connection failed: 403 Forbidden)*
- `pip show flask-socketio python-socketio` *(packages not found)*
- `python -m py_compile app.py`
- `pytest`
- `python app.py` *(failed: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_6891137f13ac83229413c24477ba6cf1