### PR TITLE
Reubicar gráficos y añadir personalización visual

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,8 +1,27 @@
 body {
-    font-family: Arial, sans-serif;
+    font-family: 'Poppins', sans-serif;
     background: #f5f5f5;
     margin: 0;
     padding: 0;
+}
+
+.main-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 20px;
+    background: #007bff;
+    color: #fff;
+}
+
+.main-header img {
+    height: 50px;
+}
+
+.customization-controls {
+    display: flex;
+    align-items: center;
+    gap: 10px;
 }
 
 .container {
@@ -123,6 +142,7 @@ canvas {
     flex-wrap: wrap;
     justify-content: center;
     gap: 20px;
+    margin-bottom: 20px;
 }
 
 .charts canvas {
@@ -135,6 +155,38 @@ canvas {
         margin: 10px;
         padding: 15px;
     }
+}
+
+/* Dark mode */
+body.dark {
+    background: #121212;
+    color: #f5f5f5;
+}
+
+body.dark .container {
+    background: #1e1e1e;
+    color: #f5f5f5;
+}
+
+body.dark .main-header {
+    background: #333;
+}
+
+body.dark table th,
+body.dark table td {
+    border-color: #444;
+}
+
+body.dark button {
+    background-color: #444;
+}
+
+body.dark button:hover {
+    background-color: #666;
+}
+
+body.dark a.logout {
+    color: #f5f5f5;
 }
 
 /* --- Formulario dinámico de votaciones --- */

--- a/static/js/asistencia.js
+++ b/static/js/asistencia.js
@@ -77,14 +77,18 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     summary.textContent = `${counts.PRESENCIAL} presenciales / ${counts.VIRTUAL} virtuales / ${counts.AUSENTE} ausentes`;
 
-    pieChart.data.datasets[0].data = [counts.PRESENCIAL, counts.VIRTUAL, counts.AUSENTE];
-    pieChart.update();
-    barChart.data.datasets[0].data = [acciones.PRESENCIAL, acciones.VIRTUAL, acciones.AUSENTE];
-    barChart.update();
+    renderCharts(counts, acciones);
 
     const totalPresentes = counts.PRESENCIAL + counts.VIRTUAL;
     const quorum = parseInt(quorumInput.value || '0', 10);
     quorumInput.style.borderColor = totalPresentes >= quorum ? 'green' : 'red';
+  }
+
+  function renderCharts(counts, acciones) {
+    pieChart.data.datasets[0].data = [counts.PRESENCIAL, counts.VIRTUAL, counts.AUSENTE];
+    pieChart.update();
+    barChart.data.datasets[0].data = [acciones.PRESENCIAL, acciones.VIRTUAL, acciones.AUSENTE];
+    barChart.update();
   }
 
   socket.on('estado_changed', ({ id, estado }) => {

--- a/static/js/customize.js
+++ b/static/js/customize.js
@@ -1,0 +1,44 @@
+// Personalización de interfaz: logo y modo oscuro
+
+document.addEventListener('DOMContentLoaded', () => {
+  const logoDisplay = document.getElementById('logoDisplay');
+  const logoInput = document.getElementById('logoInput');
+  const themeToggle = document.getElementById('themeToggle');
+  const body = document.body;
+
+  // Cargar logo guardado
+  const savedLogo = localStorage.getItem('customLogo');
+  if (savedLogo && logoDisplay) {
+    logoDisplay.src = savedLogo;
+  }
+
+  if (logoInput) {
+    logoInput.addEventListener('change', (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        logoDisplay.src = reader.result;
+        localStorage.setItem('customLogo', reader.result);
+      };
+      reader.readAsDataURL(file);
+    });
+  }
+
+  // Modo oscuro
+  const savedDark = localStorage.getItem('darkMode');
+  if (savedDark === 'true') {
+    body.classList.add('dark');
+  }
+  if (themeToggle) {
+    const updateText = () => {
+      themeToggle.textContent = body.classList.contains('dark') ? 'Modo claro' : 'Modo oscuro';
+    };
+    updateText();
+    themeToggle.addEventListener('click', () => {
+      body.classList.toggle('dark');
+      localStorage.setItem('darkMode', body.classList.contains('dark'));
+      updateText();
+    });
+  }
+});

--- a/templates/asistencia_panel.html
+++ b/templates/asistencia_panel.html
@@ -46,6 +46,11 @@
     <button id="exportPdf">Exportar PDF</button>
   </div>
 
+  <div class="charts">
+    <canvas id="pieChart" width="300" height="300"></canvas>
+    <canvas id="barChart" width="300" height="300"></canvas>
+  </div>
+
   <table id="tablaAsistencia">
     <thead>
       <tr>
@@ -60,10 +65,6 @@
   </table>
 
   <div id="summary"></div>
-  <div class="charts">
-    <canvas id="pieChart" width="300" height="300"></canvas>
-    <canvas id="barChart" width="300" height="300"></canvas>
-  </div>
 </div>
 <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,12 +4,23 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}Sistema de Votación{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-1f7ZKXu5aXoaZySUdkGFUTkOcJCIZy9lEi5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhuttW60Trw3nkwg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
 <body>
+<header class="main-header">
+    <img id="logoDisplay" alt="Logo">
+    <div class="customization-controls">
+        <input type="file" id="logoInput" accept="image/*">
+        <button id="themeToggle">Modo oscuro</button>
+    </div>
+</header>
 <div class="container">
     {% block content %}{% endblock %}
 </div>
+<script src="{{ url_for('static', filename='js/customize.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Move attendance charts above the table and summary so they render clearly
- Add header customization: user logo upload and dark mode toggle with persisted preference
- Apply Poppins font and dark-mode styling across the app

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68911a0160888322909c0ebf6f4ca365