### PR TITLE
Soporte de asistencia y registro de votos

### DIFF
--- a/static/js/asistencia.js
+++ b/static/js/asistencia.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const uploadInput = document.getElementById('fileInput');
   const uploadBtn = document.getElementById('uploadBtn');
   const templateBtn = document.getElementById('templateBtn');
+  const READONLY = window.READONLY || false;
 
   const pieChart = new Chart(document.getElementById('pieChart').getContext('2d'), {
     type: 'pie',
@@ -72,10 +73,12 @@ document.addEventListener('DOMContentLoaded', () => {
           </select>
         </td>`;
       const select = tr.querySelector('select');
-      select.addEventListener('change', () => {
-        changed.set(r.id, select.value);
-        render();
-      });
+      if (READONLY) select.disabled = true; else {
+        select.addEventListener('change', () => {
+          changed.set(r.id, select.value);
+          render();
+        });
+      }
       tbody.appendChild(tr);
       counts[currentEstado] = (counts[currentEstado] || 0) + 1;
       acciones[currentEstado] = (acciones[currentEstado] || 0) + (r.acciones || 0);
@@ -125,34 +128,36 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  document.getElementById('markAll').addEventListener('click', () => {
-    tbody.querySelectorAll('select.estado').forEach(s => {
-      s.value = 'PRESENCIAL';
-      changed.set(s.closest('tr').dataset.id, s.value);
+  if (!READONLY) {
+    document.getElementById('markAll').addEventListener('click', () => {
+      tbody.querySelectorAll('select.estado').forEach(s => {
+        s.value = 'PRESENCIAL';
+        changed.set(s.closest('tr').dataset.id, s.value);
+      });
+      render();
     });
-    render();
-  });
-  document.getElementById('markVirtual').addEventListener('click', () => {
-    tbody.querySelectorAll('select.estado').forEach(s => {
-      s.value = 'VIRTUAL';
-      changed.set(s.closest('tr').dataset.id, s.value);
+    document.getElementById('markVirtual').addEventListener('click', () => {
+      tbody.querySelectorAll('select.estado').forEach(s => {
+        s.value = 'VIRTUAL';
+        changed.set(s.closest('tr').dataset.id, s.value);
+      });
+      render();
     });
-    render();
-  });
-  document.getElementById('clearAll').addEventListener('click', () => {
-    tbody.querySelectorAll('select.estado').forEach(s => {
-      s.value = 'AUSENTE';
-      changed.set(s.closest('tr').dataset.id, s.value);
+    document.getElementById('clearAll').addEventListener('click', () => {
+      tbody.querySelectorAll('select.estado').forEach(s => {
+        s.value = 'AUSENTE';
+        changed.set(s.closest('tr').dataset.id, s.value);
+      });
+      render();
     });
-    render();
-  });
+  }
 
   document.getElementById('exportExcel').addEventListener('click', () => window.location = `/export/excel?votacion_id=${votacionSelect.value}`);
   document.getElementById('exportCsv').addEventListener('click', () => window.location = `/export/csv?votacion_id=${votacionSelect.value}`);
   document.getElementById('exportPdf').addEventListener('click', () => window.location = `/export/pdf?votacion_id=${votacionSelect.value}`);
   if (templateBtn) templateBtn.addEventListener('click', () => window.location = '/template/asistencia');
 
-  uploadBtn.addEventListener('click', () => {
+  if (uploadBtn) uploadBtn.addEventListener('click', () => {
     const file = uploadInput.files[0];
     if (!file) return alert('Seleccione un archivo');
     const fd = new FormData();
@@ -170,7 +175,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
   });
 
-  document.getElementById('save').addEventListener('click', guardar);
+  if (!READONLY) document.getElementById('save').addEventListener('click', guardar);
   search.addEventListener('input', render);
   filter.addEventListener('change', render);
   if (votacionSelect) votacionSelect.addEventListener('change', load);
@@ -179,7 +184,7 @@ document.addEventListener('DOMContentLoaded', () => {
   setInterval(() => {
     document.getElementById('clock').textContent = new Date().toLocaleTimeString();
   }, 1000);
-  setInterval(() => {
+  if (!READONLY) setInterval(() => {
     if (changed.size) guardar();
   }, 30000);
 

--- a/static/js/votacion.js
+++ b/static/js/votacion.js
@@ -1,0 +1,111 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const app = document.getElementById('votacionApp');
+  const votacionId = app.dataset.votacion;
+  let asistentes = [];
+  let preguntas = [];
+
+  async function load() {
+    const [a, p] = await Promise.all([
+      fetch(`/api/votacion/${votacionId}/asistentes`).then(r => r.json()),
+      fetch(`/api/votacion/${votacionId}/preguntas`).then(r => r.json())
+    ]);
+    asistentes = a;
+    preguntas = p;
+    render();
+  }
+
+  function render() {
+    app.innerHTML = '';
+    preguntas.forEach(p => {
+      const div = document.createElement('div');
+      div.className = 'pregunta';
+      div.innerHTML = `<h3>${p.texto}</h3>`;
+      const setAll = document.createElement('select');
+      setAll.innerHTML = `<option value="">Asignar a todos...</option>` +
+        p.opciones.map(o => `<option value="${o.id}">${o.texto}</option>`).join('');
+      setAll.addEventListener('change', () => {
+        div.querySelectorAll('select.voto').forEach(s => { s.value = setAll.value; });
+        updateResumen(div, p);
+      });
+      div.appendChild(setAll);
+
+      const table = document.createElement('table');
+      const thead = `<tr><th>Nombre</th><th>Voto</th></tr>`;
+      table.innerHTML = `<thead>${thead}</thead>`;
+      const tbody = document.createElement('tbody');
+      asistentes.forEach(a => {
+        const tr = document.createElement('tr');
+        tr.dataset.acciones = a.acciones;
+        const nombre = a.accionista || a.representante || a.apoderado || '';
+        tr.innerHTML = `<td>${nombre}</td>`;
+        const sel = document.createElement('select');
+        sel.className = 'voto';
+        sel.innerHTML = `<option value="">--</option>` +
+          p.opciones.map(o => `<option value="${o.id}">${o.texto}</option>`).join('');
+        sel.addEventListener('change', () => updateResumen(div, p));
+        tr.appendChild(sel);
+        tbody.appendChild(tr);
+      });
+      table.appendChild(tbody);
+      div.appendChild(table);
+
+      const resumen = document.createElement('div');
+      resumen.className = 'resumen';
+      div.appendChild(resumen);
+
+      const btn = document.createElement('button');
+      btn.textContent = 'Guardar votos';
+      btn.addEventListener('click', () => guardar(p, div));
+      div.appendChild(btn);
+
+      const key = `votacion_${votacionId}_p${p.id}`;
+      if (localStorage.getItem(key)) {
+        div.classList.add('votada');
+        btn.disabled = true;
+      }
+
+      app.appendChild(div);
+      updateResumen(div, p);
+    });
+  }
+
+  function updateResumen(div, p) {
+    const counts = {};
+    div.querySelectorAll('select.voto').forEach(s => {
+      counts[s.value] = (counts[s.value] || 0) + 1;
+    });
+    const res = div.querySelector('.resumen');
+    res.textContent = p.opciones.map(o => `${o.texto}: ${counts[o.id] || 0}`).join(' | ');
+  }
+
+  async function guardar(p, div) {
+    const key = `votacion_${votacionId}_p${p.id}`;
+    const peticiones = [];
+    div.querySelectorAll('tbody tr').forEach(tr => {
+      const opcion = tr.querySelector('select.voto').value;
+      if (!opcion) return;
+      const acciones = parseInt(tr.dataset.acciones || '0', 10);
+      peticiones.push(fetch('/api/votar', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          votacion_id: votacionId,
+          pregunta_id: p.id,
+          opcion_id: parseInt(opcion,10),
+          acciones
+        })
+      }));
+    });
+    try {
+      await Promise.all(peticiones);
+      localStorage.setItem(key, '1');
+      div.classList.add('votada');
+      div.querySelector('button').disabled = true;
+      alert('Votos registrados');
+    } catch (e) {
+      alert('Error al registrar votos');
+    }
+  }
+
+  load();
+});

--- a/templates/asistencia_panel.html
+++ b/templates/asistencia_panel.html
@@ -17,11 +17,13 @@
   <h2>Control de asistencia</h2>
   <div id="clock"></div>
 
+  {% if not readonly %}
   <div class="import">
     <input type="file" id="fileInput" accept=".xlsx,.xls">
     <button id="uploadBtn">Importar</button>
-    <button id="templateBtn">Descargar plantilla Excel</button>
   </div>
+  {% endif %}
+  <button id="templateBtn">Exportar plantilla de asistencia</button>
 
   <div class="filters">
     <input id="search" placeholder="Buscar por nombre">
@@ -35,10 +37,12 @@
   </div>
 
   <div class="actions">
+    {% if not readonly %}
     <button id="markAll">PRESENCIAL</button>
     <button id="markVirtual">VIRTUAL</button>
     <button id="clearAll">AUSENTE</button>
     <button id="save">Guardar</button>
+    {% endif %}
     <button id="exportExcel">Exportar Excel</button>
     <button id="exportCsv">Exportar CSV</button>
     <button id="exportPdf">Exportar PDF</button>
@@ -64,6 +68,9 @@
 
   <div id="summary"></div>
 </div>
+<script>
+  const READONLY = {{ 'true' if readonly else 'false' }};
+</script>
 <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="{{ url_for('static', filename='js/asistencia.js') }}"></script>

--- a/templates/votacion_registro.html
+++ b/templates/votacion_registro.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}Registro de Votos{% endblock %}
+{% block content %}
+<header class="header">
+  <h1>Registro de Votos - {{ votacion.nombre }}</h1>
+  <a class="logout" href="{{ url_for('logout') }}"><i class="fas fa-sign-out-alt"></i> Cerrar sesión</a>
+</header>
+<div id="votacionApp" data-votacion="{{ votacion.id }}"></div>
+<script src="{{ url_for('static', filename='js/votacion.js') }}"></script>
+{% endblock %}

--- a/templates/votante_panel.html
+++ b/templates/votante_panel.html
@@ -7,11 +7,14 @@
 </header>
 <div class="card">
   <h2>Votaciones disponibles</h2>
+  <p><a href="{{ url_for('panel_asistencia') }}">Ver asistencia (solo lectura)</a></p>
   <ul>
     {% for v in votaciones %}
       <li>
         {{ v['id'] }} - {{ v['nombre'] }}
-        <button {% if not v['quorum_ok'] %}disabled{% endif %}>Iniciar votación</button>
+        <a href="{{ url_for('iniciar_votacion', votacion_id=v['id']) }}">
+          <button {% if not v['quorum_ok'] %}disabled{% endif %}>Iniciar votación</button>
+        </a>
         {% if not v['quorum_ok'] %}
           <small>Quórum {{ v['porcentaje']|round(1) }}% / mínimo {{ v['quorum_minimo'] }}</small>
         {% endif %}


### PR DESCRIPTION
## Resumen
- Corrige la importación de Excel validando columnas, normalizando datos y entregando mensajes claros.
- Permite modo de solo lectura para votantes, quienes además pueden descargar la plantilla de asistencia.
- Implementa flujo completo de votación con preguntas, asignación masiva de respuestas y recordatorio en localStorage.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68912675b52883228494b9dc3693e1a0